### PR TITLE
feat(deploy): add PR commenting feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **deploy** action: PR commenting feature
+  - Automatically post/update a comment on PRs with the deployment URL
+  - New inputs: `comment-on-pr`, `github-token`, `comment-header`
+  - Upsert behavior: updates existing comment instead of creating duplicates
 - CI/CD pipeline with ShellCheck, actionlint, and yamllint
 - Branch protection and governance files (CODEOWNERS, issue templates, PR template)
 - CONTRIBUTING.md with development guidelines

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -35,6 +35,18 @@ inputs:
     description: 'ZAD Operations Manager API base URL'
     required: false
     default: 'https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/api'
+  comment-on-pr:
+    description: 'Post/update a comment on the PR with the deployment URL (requires github-token)'
+    required: false
+    default: 'false'
+  github-token:
+    description: 'GitHub token for PR commenting (needs pull-requests: write permission)'
+    required: false
+    default: ''
+  comment-header:
+    description: 'Custom header for the PR comment (default: "## 🚀 Preview Deployment")'
+    required: false
+    default: '## 🚀 Preview Deployment'
 
 outputs:
   url:
@@ -167,4 +179,46 @@ runs:
           echo "::error::Deployment failed (HTTP $HTTP_CODE)"
           echo "$BODY"
           exit 1
+        fi
+
+    - name: Comment on PR
+      if: inputs.comment-on-pr == 'true' && inputs.github-token != '' && github.event_name == 'pull_request'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+        COMMENT_HEADER: ${{ inputs.comment-header }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: |
+        # Build the comment body
+        COMMENT_BODY="${COMMENT_HEADER}
+
+        Your changes have been deployed to a preview environment:
+
+        **URL:** ${DEPLOYMENT_URL}
+
+        This deployment will be automatically cleaned up when the PR is closed."
+
+        # Check for existing comment from this action (identified by header)
+        EXISTING_COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+          --jq ".[] | select(.body | startswith(\"${COMMENT_HEADER}\")) | .id" \
+          2>/dev/null | head -n1 || echo "")
+
+        if [ -n "$EXISTING_COMMENT_ID" ]; then
+          # Update existing comment
+          echo "Updating existing PR comment (ID: $EXISTING_COMMENT_ID)"
+          gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_COMMENT_ID}" \
+            -X PATCH \
+            -f body="$COMMENT_BODY" \
+            --silent
+          echo "PR comment updated"
+        else
+          # Create new comment
+          echo "Creating new PR comment"
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -X POST \
+            -f body="$COMMENT_BODY" \
+            --silent
+          echo "PR comment created"
         fi


### PR DESCRIPTION
## Summary

Add ability to automatically post/update a comment on PRs with the deployment URL. This eliminates the need for a separate `actions/github-script` step in workflows.

**Before** (separate step required):
```yaml
- name: Deploy to ZAD
  id: deploy
  uses: RijksICTGilde/zad-actions/deploy@v1
  with:
    api-key: ${{ secrets.ZAD_API_KEY }}
    # ...

- name: Comment on PR
  uses: actions/github-script@v7
  with:
    script: |
      // 30+ lines of JavaScript...
```

**After** (built-in):
```yaml
- name: Deploy to ZAD
  uses: RijksICTGilde/zad-actions/deploy@v1
  with:
    api-key: ${{ secrets.ZAD_API_KEY }}
    # ...
    comment-on-pr: true
    github-token: ${{ secrets.GITHUB_TOKEN }}
```

## New Inputs

| Input | Required | Default | Description |
|-------|----------|---------|-------------|
| `comment-on-pr` | No | `false` | Enable PR commenting |
| `github-token` | No | `''` | Token with `pull-requests: write` |
| `comment-header` | No | `## 🚀 Preview Deployment` | Custom header |

## Features

- **Upsert behavior**: Updates existing comment instead of creating duplicates
- **Conditional**: Only runs on `pull_request` events
- **Customizable**: Custom header via `comment-header` input

## Example Comment

> ## 🚀 Preview Deployment
>
> Your changes have been deployed to a preview environment:
>
> **URL:** https://web-pr123-my-project.rig.prd1.gn2.quattro.rijksapps.nl
>
> This deployment will be automatically cleaned up when the PR is closed.

## Test plan

- [ ] Verify CI passes
- [ ] Test in a real PR workflow with `comment-on-pr: true`
- [ ] Verify comment is created on first deploy
- [ ] Verify comment is updated on subsequent deploys
- [ ] Verify no comment when `comment-on-pr: false` (default)

## Versioning

This is a backwards-compatible feature addition → **v1.1.0** when released.