### PR TITLE
feat(cleanup): add PR comment update feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Automatically post/update a comment on PRs with the deployment URL
   - New inputs: `comment-on-pr`, `github-token`, `comment-header`
   - Upsert behavior: updates existing comment instead of creating duplicates
+- **cleanup** action: PR comment update feature
+  - Update the deploy PR comment to show cleanup status when PR is closed
+  - New inputs: `update-pr-comment`, `comment-header`
+  - New output: `pr-comment-updated`
+  - Changes comment header from "🚀 Preview Deployment" to "🧹 Preview Deployment (Cleaned Up)"
 - CI/CD pipeline with ShellCheck, actionlint, and yamllint
 - Branch protection and governance files (CODEOWNERS, issue templates, PR template)
 - CONTRIBUTING.md with development guidelines

--- a/cleanup/action.yml
+++ b/cleanup/action.yml
@@ -53,6 +53,14 @@ inputs:
     description: 'ZAD Operations Manager API base URL'
     required: false
     default: 'https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/api'
+  update-pr-comment:
+    description: 'Update the deploy PR comment to show cleanup status (requires github-token with pull-requests:write)'
+    required: false
+    default: 'false'
+  comment-header:
+    description: 'Header of the deploy comment to find and update (default: "## 🚀 Preview Deployment")'
+    required: false
+    default: '## 🚀 Preview Deployment'
 
 outputs:
   zad-deleted:
@@ -67,6 +75,9 @@ outputs:
   container-deleted:
     description: 'Whether the container image was deleted'
     value: ${{ steps.delete-container.outputs.deleted }}
+  pr-comment-updated:
+    description: 'Whether the PR comment was updated'
+    value: ${{ steps.update-pr-comment.outputs.updated }}
 
 runs:
   using: 'composite'
@@ -261,3 +272,48 @@ runs:
         done
 
         echo "deleted=$DELETED" >> "$GITHUB_OUTPUT"
+
+    - name: Update PR Comment
+      id: update-pr-comment
+      if: inputs.update-pr-comment == 'true' && inputs.github-token != '' && github.event_name == 'pull_request'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        COMMENT_HEADER: ${{ inputs.comment-header }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        DEPLOYMENT_NAME: ${{ inputs.deployment-name }}
+        PROJECT_ID: ${{ inputs.project-id }}
+      run: |
+        # Build the updated comment body
+        COMMENT_BODY="## 🧹 Preview Deployment (Cleaned Up)
+
+        ~~https://editor-${DEPLOYMENT_NAME}-${PROJECT_ID}.rig.prd1.gn2.quattro.rijksapps.nl~~
+
+        This deployment was automatically cleaned up when the PR was closed."
+
+        # Find existing comment by header
+        EXISTING_COMMENT=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+          --jq ".[] | select(.body | startswith(\"${COMMENT_HEADER}\")) | {id: .id, body: .body}" \
+          2>/dev/null | head -n1 || echo "")
+
+        if [ -z "$EXISTING_COMMENT" ]; then
+          echo "No existing deploy comment found with header: ${COMMENT_HEADER}"
+          echo "updated=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        COMMENT_ID=$(echo "$EXISTING_COMMENT" | jq -r '.id')
+
+        if [ -n "$COMMENT_ID" ] && [ "$COMMENT_ID" != "null" ]; then
+          echo "Updating PR comment (ID: $COMMENT_ID)"
+          gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+            -X PATCH \
+            -f body="$COMMENT_BODY" \
+            --silent
+          echo "PR comment updated to show cleanup status"
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "Could not find comment ID"
+          echo "updated=false" >> "$GITHUB_OUTPUT"
+        fi


### PR DESCRIPTION
## Summary

Add ability to update the deploy PR comment when cleaning up, showing that the deployment was removed. This completes the deployment lifecycle in the PR conversation.

## Motivation

When using the deploy action's `comment-on-pr` feature, the PR gets a nice comment showing the preview URL. But when the PR is closed and cleanup runs, the comment just sits there pointing to a dead URL. This feature updates that comment to show the deployment was cleaned up.

## Changes

**Before cleanup:**
> ## 🚀 Preview Deployment
>
> Your changes have been deployed to a preview environment:
>
> **URL:** https://web-pr123-my-project.rig...
>
> This deployment will be automatically cleaned up when the PR is closed.

**After cleanup:**
> ## 🧹 Preview Deployment (Cleaned Up)
>
> ~~https://editor-pr123-my-project.rig...~~
>
> This deployment was automatically cleaned up when the PR was closed.

## New Inputs

| Input | Required | Default | Description |
|-------|----------|---------|-------------|
| `update-pr-comment` | No | `false` | Update the deploy PR comment to show cleanup status |
| `comment-header` | No | `## 🚀 Preview Deployment` | Header to find the original comment |

## New Output

| Output | Description |
|--------|-------------|
| `pr-comment-updated` | Whether the PR comment was updated (`true`/`false`) |

## Usage

```yaml
cleanup-preview:
  if: github.event_name == 'pull_request' && github.event.action == 'closed'
  runs-on: ubuntu-latest
  permissions:
    pull-requests: write
    # ... other permissions
  steps:
    - name: Cleanup
      uses: RijksICTGilde/zad-actions/cleanup@v1
      with:
        api-key: ${{ secrets.ZAD_API_KEY }}
        # ... other inputs
        update-pr-comment: true
        github-token: ${{ secrets.GITHUB_TOKEN }}
```

## Test plan

- [ ] Verify CI passes
- [ ] Test with a real PR that used `comment-on-pr: true` on deploy
- [ ] Verify comment is updated when cleanup runs
- [ ] Verify cleanup still works when `update-pr-comment: false` (default)
- [ ] Verify cleanup handles missing comment gracefully

## Versioning

Backwards-compatible feature addition → **v1.2.0** when released.