### PR TITLE
feat(cleanup)!: replace update-pr-comment with delete-pr-comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Automatically post/update a comment on PRs with the deployment URL
   - New inputs: `comment-on-pr`, `github-token`, `comment-header`
   - Upsert behavior: updates existing comment instead of creating duplicates
+- **cleanup** action: PR comment delete feature
+  - Delete the deploy PR comment when PR is closed (default: enabled)
+  - New inputs: `delete-pr-comment`, `comment-header`
+  - New output: `pr-comment-deleted`
+
 - CI/CD pipeline with ShellCheck, actionlint, and yamllint
 - Branch protection and governance files (CODEOWNERS, issue templates, PR template)
 - CONTRIBUTING.md with development guidelines
@@ -62,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deploy** and **cleanup** actions: `github-token` now defaults to `github.token`
   - No longer necessary to explicitly pass `github-token: ${{ secrets.GITHUB_TOKEN }}`
   - Only needed when using a custom PAT for cross-repository operations
+
+### Removed
+- **BREAKING** `cleanup` action: `update-pr-comment` input (use `delete-pr-comment` instead)
+- **BREAKING** `cleanup` action: `pr-comment-updated` output (use `pr-comment-deleted` instead)
 
 ### Internal
 - Added justfile for common development tasks

--- a/cleanup/action.yml
+++ b/cleanup/action.yml
@@ -53,12 +53,12 @@ inputs:
     description: 'ZAD Operations Manager API base URL'
     required: false
     default: 'https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/api'
-  update-pr-comment:
-    description: 'Update the deploy PR comment to show cleanup status (requires github-token with pull-requests:write)'
+  delete-pr-comment:
+    description: 'Delete the deploy PR comment (requires github-token with pull-requests:write)'
     required: false
-    default: 'false'
+    default: 'true'
   comment-header:
-    description: 'Header of the deploy comment to find and update (default: "## 🚀 Preview Deployment")'
+    description: 'Header of the deploy comment to find and delete (default: "## 🚀 Preview Deployment")'
     required: false
     default: '## 🚀 Preview Deployment'
 
@@ -75,9 +75,9 @@ outputs:
   container-deleted:
     description: 'Whether the container image was deleted'
     value: ${{ steps.delete-container.outputs.deleted }}
-  pr-comment-updated:
-    description: 'Whether the PR comment was updated'
-    value: ${{ steps.update-pr-comment.outputs.updated }}
+  pr-comment-deleted:
+    description: 'Whether the PR comment was deleted'
+    value: ${{ steps.delete-pr-comment.outputs.deleted }}
 
 runs:
   using: 'composite'
@@ -273,47 +273,32 @@ runs:
 
         echo "deleted=$DELETED" >> "$GITHUB_OUTPUT"
 
-    - name: Update PR Comment
-      id: update-pr-comment
-      if: inputs.update-pr-comment == 'true' && github.event_name == 'pull_request'
+    - name: Delete PR Comment
+      id: delete-pr-comment
+      if: inputs.delete-pr-comment == 'true' && github.event_name == 'pull_request'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         COMMENT_HEADER: ${{ inputs.comment-header }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         GITHUB_REPOSITORY: ${{ github.repository }}
-        DEPLOYMENT_NAME: ${{ inputs.deployment-name }}
-        PROJECT_ID: ${{ inputs.project-id }}
       run: |
-        # Build the updated comment body
-        COMMENT_BODY="## 🧹 Preview Deployment (Cleaned Up)
-
-        ~~https://editor-${DEPLOYMENT_NAME}-${PROJECT_ID}.rig.prd1.gn2.quattro.rijksapps.nl~~
-
-        This deployment was automatically cleaned up when the PR was closed."
-
         # Find existing comment by header
-        EXISTING_COMMENT=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-          --jq ".[] | select(.body | startswith(\"${COMMENT_HEADER}\")) | {id: .id, body: .body}" \
+        COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+          --jq ".[] | select(.body | startswith(\"${COMMENT_HEADER}\")) | .id" \
           2>/dev/null | head -n1 || echo "")
 
-        if [ -z "$EXISTING_COMMENT" ]; then
+        if [ -z "$COMMENT_ID" ]; then
           echo "No existing deploy comment found with header: ${COMMENT_HEADER}"
-          echo "updated=false" >> "$GITHUB_OUTPUT"
+          echo "deleted=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        COMMENT_ID=$(echo "$EXISTING_COMMENT" | jq -r '.id')
-
-        if [ -n "$COMMENT_ID" ] && [ "$COMMENT_ID" != "null" ]; then
-          echo "Updating PR comment (ID: $COMMENT_ID)"
-          gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
-            -X PATCH \
-            -f body="$COMMENT_BODY" \
-            --silent
-          echo "PR comment updated to show cleanup status"
-          echo "updated=true" >> "$GITHUB_OUTPUT"
+        echo "Deleting PR comment (ID: $COMMENT_ID)"
+        if gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" -X DELETE 2>/dev/null; then
+          echo "PR comment deleted successfully"
+          echo "deleted=true" >> "$GITHUB_OUTPUT"
         else
-          echo "Could not find comment ID"
-          echo "updated=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::Failed to delete PR comment"
+          echo "deleted=false" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
## Description

When a PR is closed, the preview deployment is no longer relevant. A strikethrough URL in the comment adds no value - it's just visual noise. Better to simply delete the comment and keep the PR clean.

This aligns with how [pr-preview-action](https://github.com/rossjrw/pr-preview-action) works: delete is the default there too.

| Old (v1) | New (v2) |
|----------|----------|
| `update-pr-comment: true` | `delete-pr-comment: true` |
| `pr-comment-updated` output | `pr-comment-deleted` output |
| Default: `false` | Default: `true` |

## Type of Change

- [x] Breaking change (changes to action inputs/outputs)

## Checklist

- [ ] I have tested these changes locally
- [x] I have updated the documentation (if applicable)
- [x] My changes follow the existing code style
- [x] I have added/updated comments where necessary

## Breaking Changes

Users upgrading to v2 must replace `update-pr-comment` with `delete-pr-comment`.