### PR TITLE
feat(deploy): add wait-for-ready feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.github/dependabot.yml` for automated GitHub Actions updates
 - `.gitignore` for local settings and Claude plans
 - `.claude/` configuration for AI assistant (coding rules, skills, workflow)
+- **deploy** action: Wait for ready feature
+  - Wait for deployment to be reachable before continuing
+  - New inputs: `wait-for-ready`, `health-endpoint`, `wait-timeout`, `wait-interval`
+  - Polls deployment URL until HTTP 2xx/3xx or timeout
+  - PR comment only appears after deployment is healthy (when combined with `comment-on-pr`)
 
 ### Changed
 - `.pre-commit-config.yaml`: require minimum version 4.5.0

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -47,6 +47,22 @@ inputs:
     description: 'Custom header for the PR comment (default: "## 🚀 Preview Deployment")'
     required: false
     default: '## 🚀 Preview Deployment'
+  wait-for-ready:
+    description: 'Wait for deployment to be reachable before continuing'
+    required: false
+    default: 'false'
+  health-endpoint:
+    description: 'Endpoint to check for readiness (e.g., /, /health)'
+    required: false
+    default: '/'
+  wait-timeout:
+    description: 'Maximum time to wait for deployment in seconds'
+    required: false
+    default: '300'
+  wait-interval:
+    description: 'Seconds between readiness checks'
+    required: false
+    default: '10'
 
 outputs:
   url:
@@ -180,6 +196,35 @@ runs:
           echo "$BODY"
           exit 1
         fi
+
+    - name: Wait for deployment to be ready
+      if: inputs.wait-for-ready == 'true'
+      shell: bash
+      env:
+        DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+        HEALTH_ENDPOINT: ${{ inputs.health-endpoint }}
+        WAIT_TIMEOUT: ${{ inputs.wait-timeout }}
+        WAIT_INTERVAL: ${{ inputs.wait-interval }}
+      run: |
+        URL="${DEPLOYMENT_URL}${HEALTH_ENDPOINT}"
+        echo "Waiting for $URL to be ready..."
+
+        ELAPSED=0
+        while [ "$ELAPSED" -lt "$WAIT_TIMEOUT" ]; do
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$URL" || echo "000")
+
+          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 400 ]; then
+            echo "Deployment is ready (HTTP $HTTP_CODE)"
+            exit 0
+          fi
+
+          echo "Waiting... (HTTP $HTTP_CODE, ${ELAPSED}s elapsed)"
+          sleep "$WAIT_INTERVAL"
+          ELAPSED=$((ELAPSED + WAIT_INTERVAL))
+        done
+
+        echo "::error::Deployment did not become ready within ${WAIT_TIMEOUT}s"
+        exit 1
 
     - name: Comment on PR
       if: inputs.comment-on-pr == 'true' && github.event_name == 'pull_request'


### PR DESCRIPTION
## Description

Add optional health checking to wait for deployments to be reachable before continuing. This ensures that workflows can reliably wait for a deployment to be ready before proceeding with subsequent steps like integration tests.

New inputs:
- `wait-for-ready`: enable waiting (default: false)
- `health-endpoint`: path to check (default: /)
- `wait-timeout`: max wait time in seconds (default: 300)
- `wait-interval`: time between checks (default: 10)

When combined with `comment-on-pr`, the PR comment only appears after the deployment is healthy.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (changes to action inputs/outputs)
- [x] Documentation update

## Checklist

- [ ] I have tested these changes locally
- [x] I have updated the documentation (if applicable)
- [x] My changes follow the existing code style
- [x] I have added/updated comments where necessary

## Testing

- Verified bash script logic locally
- Validated action.yml syntax with actionlint
- Updated README examples to use the new feature

## Breaking Changes

None. All new inputs are optional with sensible defaults.