### PR TITLE
fix(ci): add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -53,6 +55,8 @@ jobs:
   actionlint:
     name: Action Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -67,6 +71,8 @@ jobs:
   yaml-lint:
     name: YAML Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Security
+- CI workflow: Add explicit `permissions: contents: read` to all jobs to comply with GitHub security best practices
+
 ## [2.0.1] - 2026-02-06
 
 ### Fixed


### PR DESCRIPTION
Add explicit `permissions: contents: read` to all CI workflow jobs to resolve CodeQL security alerts.