### PR TITLE
feat(skills): enrich skills and add generate-workflow and debug-deploy

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zad-actions",
-  "description": "Skills voor ZAD deployment: linting, releases en GitHub Actions validatie voor Zelfservice voor Applicatie Deployment.",
-  "version": "1.0.0",
+  "description": "Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en deployment debugging voor Zelfservice voor Applicatie Deployment.",
+  "version": "1.1.0",
   "skills": "./.claude/skills/"
 }

--- a/.claude/skills/generate-workflow/SKILL.md
+++ b/.claude/skills/generate-workflow/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: generate-workflow
+description: >-
+  Genereer een GitHub Actions workflow voor een repo die zad-actions
+  deploy/cleanup gebruikt. Gebruik bij 'workflow genereren', 'hoe gebruik ik
+  zad-actions', 'setup zad', 'integratie', 'voorbeeld workflow'.
+model: sonnet
+allowed-tools:
+  - Read(*)
+---
+
+# Generate ZAD Workflow
+
+Generate a complete GitHub Actions workflow for a repository that uses zad-actions for deployment.
+
+## Usage
+
+```
+/generate-workflow
+```
+
+Or with arguments: `/generate-workflow project-id=my-project component=web`
+
+## Steps
+
+1. **Gather project details.** Ask the user for (or accept as arguments):
+   - `project-id` (required): ZAD project identifier (e.g., `regel-k4c`)
+   - `component` (required): Component reference (e.g., `web`, `api`, `editor`)
+   - `container-registry` (optional, default: `ghcr.io`): Container registry to use
+   - `image-name` (optional, default: `${{ github.repository }}`): Docker image name
+   - Features to enable (ask the user):
+     - `wait-for-ready` — wait for deployment health check
+     - `qr-code` — QR code in PR comment for mobile testing
+     - `comment-on-pr` — post deployment URL as PR comment
+     - `clone-from` — clone config from existing deployment (e.g., `production`)
+     - `production-deploy` — add production deploy job on push to main
+
+2. **Read current action inputs** from `deploy/action.yml` and `cleanup/action.yml` to ensure generated workflow uses correct input names and defaults.
+
+3. **Generate the workflow file** with the following structure:
+
+```yaml
+name: Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+  push:
+    branches: [main]  # only if production-deploy enabled
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}
+
+  deploy-preview:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # if comment-on-pr
+    environment:
+      name: pr-${{ github.event.pull_request.number }}
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Deploy to ZAD
+        id: deploy
+        uses: RijksICTGilde/zad-actions/deploy@v2
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY }}
+          project-id: <project-id>
+          deployment-name: pr-${{ github.event.pull_request.number }}
+          component: <component>
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}
+
+  cleanup-preview:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Cleanup
+        uses: RijksICTGilde/zad-actions/cleanup@v2
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY }}
+          project-id: <project-id>
+          deployment-name: pr-${{ github.event.pull_request.number }}
+          delete-github-env: 'true'
+          delete-github-deployments: 'true'
+          delete-container: 'true'
+          container-org: ${{ github.repository_owner }}
+          container-name: ${{ github.event.repository.name }}
+          container-tag: pr-${{ github.event.number }}
+          github-admin-token: ${{ secrets.GITHUB_ADMIN_TOKEN }}
+```
+
+4. **Add inline YAML comments** explaining:
+   - Why each `permissions:` block is needed
+   - What each secret is for
+   - What optional features do
+
+5. **List required secrets** the user must configure:
+   - `ZAD_API_KEY` (always required) — ZAD Operations Manager API key
+   - `GITHUB_ADMIN_TOKEN` (if `delete-github-env` is used) — PAT with repo admin permissions
+
+6. **Output the workflow** as a code block the user can copy, or write directly to `.github/workflows/deploy.yml` if the user confirms.
+
+## Important notes
+
+- Always use `@v2` for zad-actions references (current major version)
+- The `github-token` input defaults to `${{ github.token }}` so it doesn't need to be passed explicitly
+- `pull-requests: write` permission is needed for `comment-on-pr` and `delete-pr-comment`
+- `packages: delete` permission is needed for container deletion (note: different from `packages: write`)
+- ZAD URL pattern: `https://{component}-{deployment}-{project}.rig.prd1.gn2.quattro.rijksapps.nl`

--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -9,11 +9,42 @@ allowed-tools:
   - Bash(uv tool install *)
 ---
 
-Run `pre-commit run --all-files` om alle linting checks uit te voeren.
+# Lint ZAD Actions
 
-Als pre-commit niet geinstalleerd is:
+Run pre-commit linting with automatic fixing.
 
-```bash
-uv tool install pre-commit
-pre-commit install
-```
+## Steps
+
+1. **Check pre-commit is installed:**
+   ```bash
+   command -v pre-commit
+   ```
+   If not installed:
+   ```bash
+   uv tool install pre-commit
+   pre-commit install
+   ```
+
+2. **Run pre-commit on all files:**
+   ```bash
+   pre-commit run --all-files
+   ```
+
+3. **If there are failures:** Read the error output carefully, then fix the issues:
+   - **YAML lint errors**: Fix indentation, trailing spaces, or line length in `.yml`/`.yaml` files
+   - **ShellCheck warnings**: Fix bash issues in `action.yml` `run:` blocks
+   - **Trailing whitespace / end-of-file**: These are usually auto-fixed by pre-commit — just re-run
+   - **actionlint errors**: Fix GitHub Actions syntax issues in `.github/workflows/` files
+
+4. **Re-run to verify fixes:**
+   ```bash
+   pre-commit run --all-files
+   ```
+
+5. **Report summary:** List what was fixed and what still fails (if anything).
+
+## Important
+
+- Pre-commit auto-fixes some issues (trailing whitespace, end-of-file). After the first run, check if files were modified and re-run.
+- Always use `uv tool install` (not `pip install`) per project conventions.
+- The pre-commit config is in `.pre-commit-config.yaml` at the repo root.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -7,18 +7,67 @@ model: sonnet
 allowed-tools:
   - Bash(git tag *)
   - Bash(git push *)
+  - Bash(git fetch *)
   - Read(*)
 ---
 
-## Release maken
+# Release ZAD Actions
 
-1. Controleer dat CHANGELOG.md een entry heeft voor de versie (`## [<version>]`)
-2. Extraheer de release notes uit CHANGELOG voor deze versie
-3. Maak en push een versie-tag:
+Create a validated release with annotated tag.
 
-```bash
-git tag -a v<version> -m "<release notes uit changelog>"
-git push origin v<version>
+## Usage
+
+```
+/release <version>
 ```
 
-De release workflow handelt de rest af. We volgen [Semantic Versioning](https://semver.org/).
+Example: `/release 2.1.0`
+
+If no version is provided, ask the user for one.
+
+## Steps
+
+1. **Validate semver format:**
+   The version argument must match `X.Y.Z` (e.g., `2.1.0`). Reject anything else.
+
+2. **Check for duplicate tags:**
+   ```bash
+   git fetch --tags
+   git tag -l "v<version>"
+   ```
+   If the tag already exists, abort and inform the user.
+
+3. **Validate CHANGELOG.md:**
+   Read `CHANGELOG.md` and verify:
+   - A `## [<version>]` section exists with content
+   - The `## [Unreleased]` section is empty (all changes moved to the version section)
+   - A comparison link exists at the bottom: `[<version>]: https://github.com/RijksICTGilde/zad-actions/releases/tag/v<version>`
+   - The comparison links are in correct order (newest first)
+
+   If any of these fail, fix them or tell the user what needs to change.
+
+4. **Major version warning:**
+   If the major version changes (e.g., `1.x.x` to `2.0.0`), warn the user:
+   - Breaking changes require updating the `## Migration from vX` section
+   - Users referencing `@v1` will NOT get this update (they need `@v2`)
+
+5. **Extract release notes:**
+   Extract the content between `## [<version>]` and the next `## [` heading from CHANGELOG.md.
+
+6. **Create and push annotated tag:**
+   ```bash
+   git tag -a "v<version>" -m "<release notes>"
+   git push origin "v<version>"
+   ```
+
+   The release workflow (`.github/workflows/release.yml`) handles:
+   - Creating the GitHub Release
+   - Updating the major version tag (e.g., `v2`)
+   - Rolling back the tag on failure
+
+## Semver rules
+
+We follow [Semantic Versioning](https://semver.org/):
+- **Major** (X.0.0): Breaking changes (removed/renamed inputs, changed behavior)
+- **Minor** (x.Y.0): New features (new inputs, new actions)
+- **Patch** (x.y.Z): Bug fixes, documentation changes

--- a/.claude/skills/validate-action/SKILL.md
+++ b/.claude/skills/validate-action/SKILL.md
@@ -11,12 +11,68 @@ allowed-tools:
   - Glob(*)
 ---
 
-## Valideer een action.yml
+# Validate GitHub Action
 
-Valideer het `deploy` of `cleanup` action.yml bestand:
+Deep validation of action.yml files in this repo.
 
-1. Controleer verplichte velden: name, description, branding, input/output beschrijvingen
-2. Verifieer dat `${{ inputs.* }}` referenties bestaan als gedefinieerde inputs
-3. Verifieer dat output values verwijzen naar geldige step IDs
-4. Controleer dat README.md overeenkomt met action.yml (inputs, outputs, voorbeelden)
-5. Rapporteer problemen met regelnummers
+## Usage
+
+```
+/validate-action <action>
+```
+
+Where `<action>` is `deploy` or `cleanup`. If not specified, validate both.
+
+## Validation checks
+
+### 1. Structural validation
+
+Read `<action>/action.yml` and verify:
+
+- **Top-level fields exist:** `name`, `description`, `author`, `branding`, `inputs`, `outputs`, `runs`
+- **Every input has:**
+  - `description` (non-empty string)
+  - `required` explicitly set to `true` or `false` (not omitted)
+- **Every output has:**
+  - `description` (non-empty string)
+  - `value` referencing a valid step output
+
+### 2. Cross-reference validation
+
+- **Input references:** Every `${{ inputs.X }}` in `run:` blocks and `env:` mappings must correspond to a defined input `X`
+- **Step output references:** Every `${{ steps.X.outputs.Y }}` must reference:
+  - A step with `id: X` that exists in the action
+  - An output `Y` that the step actually sets (via `>> "$GITHUB_OUTPUT"`)
+- **Output values:** Every output `value: ${{ steps.X.outputs.Y }}` must reference a valid step ID and output name
+
+### 3. Security validation
+
+Check bash scripts in `run:` blocks for:
+
+- **Sensitive inputs via env:** Inputs like `api-key`, tokens, and secrets must be passed via `env:` block, not interpolated directly in `run:` strings
+- **curl timeouts:** Every `curl` command must have `--max-time`
+- **Input validation before logging:** Inputs used in `echo` or log statements should be validated first (grep pattern check before echo)
+- **Variable quoting:** All `$VARIABLE` expansions in bash should be quoted (`"$VARIABLE"`)
+
+### 4. README sync check
+
+Read `README.md` and compare with `<action>/action.yml`:
+
+- **Inputs table:** Every input in action.yml should appear in README examples or documentation
+- **Outputs table:** Every output in action.yml should be documented
+- **Defaults:** Default values mentioned in README should match action.yml
+- **Version references:** `@v1` or `@v2` references should match current major version
+
+### 5. Report format
+
+Report issues grouped by category with:
+- File path and line number (e.g., `deploy/action.yml:42`)
+- Severity: ERROR (must fix) or WARNING (should fix)
+- Description of the issue
+- Suggested fix
+
+Example:
+```
+ERROR deploy/action.yml:83 - Input 'api-key' interpolated directly in run: block (should use env:)
+WARNING README.md:45 - Input 'wait-interval' not documented in README
+```


### PR DESCRIPTION
## Summary

- Enrich the 3 existing skills (`/lint`, `/release`, `/validate-action`) with detailed step-by-step instructions, validation checks, and auto-fix guidance
- Add 2 new skills: `/generate-workflow` for creating complete deploy/cleanup workflows, and `/debug-deploy` for diagnosing deployment failures with a diagnostic decision tree
- Bump plugin version to 1.1.0

## Changes

| Skill | Change |
|-------|--------|
| `/lint` | Added auto-fix flow: detect failures, fix issues, re-run, report summary |
| `/release` | Added semver validation, duplicate tag check, CHANGELOG link validation, major version warning |
| `/validate-action` | Added cross-reference validation, security checks, README sync verification |
| `/generate-workflow` | **New** — generates complete workflow with build+deploy+cleanup+permissions |
| `/debug-deploy` | **New** — diagnostic decision tree for HTTP errors, token confusion, permissions |

## Test plan

- [ ] Start new Claude Code session and verify all 5 skills appear as slash commands
- [ ] Test `/lint` — runs pre-commit and fixes issues
- [ ] Test `/validate-action deploy` — validates action.yml
- [ ] Test `/release` without argument — asks for version number
- [ ] Test `/generate-workflow` — asks for project details
- [ ] Test `/debug-deploy HTTP 401` — gives diagnosis