### PR TITLE
docs: update all references from @v3 to @v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Reusable GitHub Actions for deploying to [ZAD](https://github.com/RijksICTGilde/
 
 ```yaml
 - name: Deploy to ZAD
-  uses: RijksICTGilde/zad-actions/deploy@v3
+  uses: RijksICTGilde/zad-actions/deploy@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -34,7 +34,7 @@ Reusable GitHub Actions for deploying to [ZAD](https://github.com/RijksICTGilde/
 
 ```yaml
 - name: Deploy to ZAD
-  uses: RijksICTGilde/zad-actions/deploy@v3
+  uses: RijksICTGilde/zad-actions/deploy@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -50,7 +50,7 @@ Reusable GitHub Actions for deploying to [ZAD](https://github.com/RijksICTGilde/
 
 ```yaml
 - name: Cleanup ZAD deployment
-  uses: RijksICTGilde/zad-actions/cleanup@v3
+  uses: RijksICTGilde/zad-actions/cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -69,7 +69,7 @@ Reusable GitHub Actions for deploying to [ZAD](https://github.com/RijksICTGilde/
 
 ```yaml
 - name: Cleanup ZAD deployment
-  uses: RijksICTGilde/zad-actions/cleanup@v3
+  uses: RijksICTGilde/zad-actions/cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -100,7 +100,7 @@ jobs:
       packages: write
       pull-requests: read
     steps:
-      - uses: RijksICTGilde/zad-actions/scheduled-cleanup@v3
+      - uses: RijksICTGilde/zad-actions/scheduled-cleanup@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: my-project
@@ -178,7 +178,7 @@ jobs:
     steps:
       - name: Deploy to ZAD
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@v3
+        uses: RijksICTGilde/zad-actions/deploy@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: my-project
@@ -195,7 +195,7 @@ jobs:
       packages: write
     steps:
       - name: Cleanup
-        uses: RijksICTGilde/zad-actions/cleanup@v3
+        uses: RijksICTGilde/zad-actions/cleanup@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: my-project
@@ -219,7 +219,7 @@ jobs:
     steps:
       - name: Deploy to ZAD
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@v3
+        uses: RijksICTGilde/zad-actions/deploy@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: my-project
@@ -230,9 +230,8 @@ jobs:
 
 ## ZAD Operations Manager API
 
-These actions use the ZAD Operations Manager V2 async API. Operations are submitted as tasks and polled for completion.
+These actions use [zad-cli](https://github.com/RijksICTGilde/zad-cli) to interact with the ZAD Operations Manager API. The CLI handles retries, task polling, and error reporting.
 
-- **Base URL**: `https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/api/v2`
 - **API Docs**: `https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/docs`
 
 ### URL Pattern

--- a/cleanup/README.md
+++ b/cleanup/README.md
@@ -44,7 +44,7 @@ Removes a ZAD deployment and optionally cleans up associated GitHub resources (e
 
 ```yaml
 - name: Cleanup ZAD deployment
-  uses: RijksICTGilde/zad-actions/cleanup@v3
+  uses: RijksICTGilde/zad-actions/cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: regel-k4c
@@ -55,7 +55,7 @@ Removes a ZAD deployment and optionally cleans up associated GitHub resources (e
 
 ```yaml
 - name: Full cleanup
-  uses: RijksICTGilde/zad-actions/cleanup@v3
+  uses: RijksICTGilde/zad-actions/cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: regel-k4c
@@ -73,7 +73,7 @@ Removes a ZAD deployment and optionally cleans up associated GitHub resources (e
 
 ```yaml
 - name: Full cleanup
-  uses: RijksICTGilde/zad-actions/cleanup@v3
+  uses: RijksICTGilde/zad-actions/cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -98,7 +98,7 @@ cleanup-preview:
     pull-requests: write  # For delete-pr-comment
   steps:
     - name: Cleanup PR preview
-      uses: RijksICTGilde/zad-actions/cleanup@v3
+      uses: RijksICTGilde/zad-actions/cleanup@v4
       with:
         api-key: ${{ secrets.ZAD_API_KEY }}
         project-id: my-project
@@ -118,7 +118,7 @@ cleanup-preview:
 When used with the deploy action's `comment-on-pr` feature, the cleanup action can remove the PR comment when the deployment is cleaned up:
 
 ```yaml
-- uses: RijksICTGilde/zad-actions/cleanup@v3
+- uses: RijksICTGilde/zad-actions/cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -157,7 +157,7 @@ permissions:
 For automated periodic cleanup of stale PR environments, use the dedicated [scheduled-cleanup](../scheduled-cleanup) action instead of scripting it manually. It handles environment discovery, PR state checking, and cleanup with retry logic built in.
 
 ```yaml
-- uses: RijksICTGilde/zad-actions/scheduled-cleanup@v3
+- uses: RijksICTGilde/zad-actions/scheduled-cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -175,7 +175,7 @@ Check cleanup results and take action:
 ```yaml
 - name: Cleanup deployment
   id: cleanup
-  uses: RijksICTGilde/zad-actions/cleanup@v3
+  uses: RijksICTGilde/zad-actions/cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -47,7 +47,7 @@ Deploys a container image to ZAD Operations Manager.
 
 ```yaml
 - name: Deploy to ZAD
-  uses: RijksICTGilde/zad-actions/deploy@v3
+  uses: RijksICTGilde/zad-actions/deploy@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -61,7 +61,7 @@ Deploys a container image to ZAD Operations Manager.
 ```yaml
 - name: Deploy PR Preview
   id: deploy
-  uses: RijksICTGilde/zad-actions/deploy@v3
+  uses: RijksICTGilde/zad-actions/deploy@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -83,7 +83,7 @@ deploy-preview:
     pull-requests: write
   steps:
     - name: Deploy PR Preview
-      uses: RijksICTGilde/zad-actions/deploy@v3
+      uses: RijksICTGilde/zad-actions/deploy@v4
       with:
         api-key: ${{ secrets.ZAD_API_KEY }}
         project-id: my-project
@@ -136,7 +136,7 @@ deploy:
   steps:
     - name: Deploy to ZAD
       id: deploy
-      uses: RijksICTGilde/zad-actions/deploy@v3
+      uses: RijksICTGilde/zad-actions/deploy@v4
       with:
         api-key: ${{ secrets.ZAD_API_KEY }}
         project-id: my-project
@@ -192,7 +192,7 @@ Formats containing `subdomain` require the `subdomain` input to be set.
 
 ```yaml
 - name: Deploy with custom domain
-  uses: RijksICTGilde/zad-actions/deploy@v3
+  uses: RijksICTGilde/zad-actions/deploy@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -221,7 +221,7 @@ Deploy multiple components in a single action invocation:
 
 ```yaml
 - name: Deploy all components
-  uses: RijksICTGilde/zad-actions/deploy@v3
+  uses: RijksICTGilde/zad-actions/deploy@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -260,7 +260,7 @@ deploy:
       component: [frontend, api, worker]
   steps:
     - name: Deploy ${{ matrix.component }}
-      uses: RijksICTGilde/zad-actions/deploy@v3
+      uses: RijksICTGilde/zad-actions/deploy@v4
       with:
         api-key: ${{ secrets.ZAD_API_KEY }}
         project-id: my-project
@@ -279,7 +279,7 @@ deploy:
   steps:
     - name: Deploy to preview
       if: github.ref == 'refs/heads/staging'
-      uses: RijksICTGilde/zad-actions/deploy@v3
+      uses: RijksICTGilde/zad-actions/deploy@v4
       with:
         api-key: ${{ secrets.ZAD_API_KEY }}
         project-id: my-project
@@ -289,7 +289,7 @@ deploy:
 
     - name: Deploy to production
       if: github.ref == 'refs/heads/main'
-      uses: RijksICTGilde/zad-actions/deploy@v3
+      uses: RijksICTGilde/zad-actions/deploy@v4
       with:
         api-key: ${{ secrets.ZAD_API_KEY }}
         project-id: my-project
@@ -304,7 +304,7 @@ If your application is served under a subpath (e.g. `/docs/`), use `path-suffix`
 
 ```yaml
 - name: Deploy to ZAD
-  uses: RijksICTGilde/zad-actions/deploy@v3
+  uses: RijksICTGilde/zad-actions/deploy@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -322,7 +322,7 @@ Wait for deployment to be healthy using the built-in `wait-for-ready` feature:
 
 ```yaml
 - name: Deploy to ZAD
-  uses: RijksICTGilde/zad-actions/deploy@v3
+  uses: RijksICTGilde/zad-actions/deploy@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project

--- a/scheduled-cleanup/README.md
+++ b/scheduled-cleanup/README.md
@@ -57,7 +57,7 @@ jobs:
       packages: write
       pull-requests: read
     steps:
-      - uses: RijksICTGilde/zad-actions/scheduled-cleanup@v3
+      - uses: RijksICTGilde/zad-actions/scheduled-cleanup@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: my-project
@@ -73,7 +73,7 @@ jobs:
 Test what would be cleaned up without actually deleting anything:
 
 ```yaml
-- uses: RijksICTGilde/zad-actions/scheduled-cleanup@v3
+- uses: RijksICTGilde/zad-actions/scheduled-cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -85,7 +85,7 @@ Test what would be cleaned up without actually deleting anything:
 Clean up environments older than 30 days, even if the PR is still open:
 
 ```yaml
-- uses: RijksICTGilde/zad-actions/scheduled-cleanup@v3
+- uses: RijksICTGilde/zad-actions/scheduled-cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project
@@ -97,7 +97,7 @@ Clean up environments older than 30 days, even if the PR is still open:
 If your environments use a different naming convention (e.g., `preview-123`):
 
 ```yaml
-- uses: RijksICTGilde/zad-actions/scheduled-cleanup@v3
+- uses: RijksICTGilde/zad-actions/scheduled-cleanup@v4
   with:
     api-key: ${{ secrets.ZAD_API_KEY }}
     project-id: my-project

--- a/scripts/zad-common.sh
+++ b/scripts/zad-common.sh
@@ -5,7 +5,7 @@
 
 # Install zad-cli if not already available.
 # Pin to a specific version tag to prevent breaking changes.
-ZAD_CLI_VERSION="v0.1.1"
+ZAD_CLI_VERSION="v0.1.2"
 
 install_zad_cli() {
   if command -v zad >/dev/null 2>&1; then

--- a/skills/generate-workflow/SKILL.md
+++ b/skills/generate-workflow/SKILL.md
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Deploy to ZAD
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@v3
+        uses: RijksICTGilde/zad-actions/deploy@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: <project-id>
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Deploy to ZAD
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@v3
+        uses: RijksICTGilde/zad-actions/deploy@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: <project-id>
@@ -145,7 +145,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Cleanup
-        uses: RijksICTGilde/zad-actions/cleanup@v3
+        uses: RijksICTGilde/zad-actions/cleanup@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: <project-id>
@@ -173,7 +173,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Cleanup
-        uses: RijksICTGilde/zad-actions/cleanup@v3
+        uses: RijksICTGilde/zad-actions/cleanup@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: <project-id>
@@ -198,7 +198,7 @@ jobs:
       packages: write
       pull-requests: read
     steps:
-      - uses: RijksICTGilde/zad-actions/scheduled-cleanup@v3
+      - uses: RijksICTGilde/zad-actions/scheduled-cleanup@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: <project-id>


### PR DESCRIPTION
## Summary
- Update all `@v3` references to `@v4` across READMEs and the generate-workflow skill
- Update root README API section to reflect zad-cli usage instead of direct API calls

## Test plan
- [ ] Verify no remaining `@v3` references: `grep -r 'zad-actions.*@v3' .`