### PR TITLE
fix: bump zad-cli to v0.2.1

### DIFF
--- a/scripts/zad-common.sh
+++ b/scripts/zad-common.sh
@@ -5,7 +5,7 @@
 
 # Install zad-cli if not already available.
 # Pin to a specific version tag to prevent breaking changes.
-ZAD_CLI_VERSION="v0.1.2"
+ZAD_CLI_VERSION="v0.2.1"
 
 install_zad_cli() {
   if command -v zad >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Bumpt zad-cli van v0.1.2 naar v0.2.1
- Fixt crash bij task polling wanneer de ZAD API een lege response body teruggeeft (RijksICTGilde/zad-cli#11)

## Test plan
- [ ] Bouwmeester deploy opnieuw triggeren na merge om te verifiëren dat de fix werkt