### PR TITLE
fix: bump zad-cli to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.3] - 2026-04-21
+
+### Changed
+- Bump zad-cli from v0.2.1 to v0.3.0 (syncs with upstream ZAD API changes from 2026-04-20)
+
+## [4.0.2] - 2026-04-21
+
+### Changed
+- Bump zad-cli from v0.1.2 to v0.2.1 (fixes crash on empty task-polling response, RijksICTGilde/zad-cli#11)
+
 ## [4.0.1] - 2026-04-07
 
 ### Changed

--- a/scripts/zad-common.sh
+++ b/scripts/zad-common.sh
@@ -5,7 +5,7 @@
 
 # Install zad-cli if not already available.
 # Pin to a specific version tag to prevent breaking changes.
-ZAD_CLI_VERSION="v0.2.1"
+ZAD_CLI_VERSION="v0.3.0"
 
 install_zad_cli() {
   if command -v zad >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Bumpt zad-cli van v0.2.1 naar v0.3.0
- Alleen de upstream OpenAPI-spec is ververst (2026-04-20), geen wijzigingen aan CLI-commando's of flags die wij gebruiken (`deployment create/delete`, `--output json`, `--yes`, `--ignore-not-found`, `version`)
- Backfillt ook de ontbrekende v4.0.2 CHANGELOG-entry (zie #44)

## Test plan
- [ ] Volgende deploy (bijv. Bouwmeester) triggeren na merge om te verifiëren dat de v0.3.0 install werkt tegen de huidige ZAD API