### PR TITLE
docs: add CHANGELOG entry for action-gh-release v3 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Bump `softprops/action-gh-release` from v2 to v3 in release workflow (moves release job to Node 24 runtime)
+
 ## [4.0.3] - 2026-04-21
 
 ### Changed


### PR DESCRIPTION
## Summary
- Backfillt CHANGELOG entry voor #45 (softprops/action-gh-release v2 → v3)
- Geen consumer-visible wijziging — release.yml draait alleen op tag push uit deze repo
- Onder `[Unreleased]` zodat de entry meegaat in de volgende echte release

## Test plan
- [ ] Niet nodig: alleen documentatie