### PR TITLE
fix: bump zad-cli to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Bump zad-cli from v0.3.0 to v0.5.0 (v2 deployment read endpoints, mutation confirmations, faster `describe`, plus error/validation fixes)
 - Bump `softprops/action-gh-release` from v2 to v3 in release workflow (moves release job to Node 24 runtime)
 
 ## [4.0.3] - 2026-04-21

--- a/scripts/zad-common.sh
+++ b/scripts/zad-common.sh
@@ -5,7 +5,7 @@
 
 # Install zad-cli if not already available.
 # Pin to a specific version tag to prevent breaking changes.
-ZAD_CLI_VERSION="v0.3.0"
+ZAD_CLI_VERSION="v0.5.0"
 
 install_zad_cli() {
   if command -v zad >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Bumps `ZAD_CLI_VERSION` in `scripts/zad-common.sh` from v0.3.0 to v0.5.0
- Picks up v0.4.0 (mutation confirmations, faster `describe`, server-side task filter) and v0.5.0 (v2 deployment read endpoints, error/validation fixes, drops legacy logs+tasks fallback)
- CHANGELOG entry added under [Unreleased]

## Test plan
- [ ] CI green on this PR
- [ ] After merge, smoke-test deploy + cleanup against a real ZAD project before tagging v4.0.4