### PR TITLE
chore(deps): bump zad-cli to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Bump zad-cli from v0.5.0 to v0.6.0 (restore deployment, pvc-snapshots and admin commands, async admin delete, syncs with upstream ZAD API changes from 2026-05-18; zad-cli drops the `-s` alias and renders list commands as tables, but the actions do not parse that output so no behaviour change here)
+
 ## [4.0.4] - 2026-05-07
 
 ### Changed

--- a/scripts/zad-common.sh
+++ b/scripts/zad-common.sh
@@ -5,7 +5,7 @@
 
 # Install zad-cli if not already available.
 # Pin to a specific version tag to prevent breaking changes.
-ZAD_CLI_VERSION="v0.5.0"
+ZAD_CLI_VERSION="v0.6.0"
 
 install_zad_cli() {
   if command -v zad >/dev/null 2>&1; then


### PR DESCRIPTION
## Wat

Bumpt de gepinde zad-cli versie van `v0.5.0` naar `v0.6.0` in `scripts/zad-common.sh`.

## Waarom

zad-cli v0.6.0 synct met upstream ZAD API-wijzigingen van 2026-05-18 en voegt nieuwe commando's toe (restore deployment, pvc-snapshots, admin), plus async admin delete.

## Impact op deze actions

Geen gedragsverandering. De actions roepen alleen aan:

- `zad --output json deployment create <name> --yes` (deploy)
- `zad --output json deployment delete <name> --yes --ignore-not-found` (cleanup, via gedeelde helper)
- `zad version`

De breaking changes in v0.6.0 (gedropte `-s` alias, lijst-commando's als tabel in plaats van platte output) raken geen van deze aanroepen, omdat alles via `--output json` loopt en er geen lijst-commando's of `-s` worden gebruikt.

## Checks

Lokaal gedraaid, allemaal groen: plugin-validatie + sync, shellcheck, actionlint, yamllint.