### PR TITLE
chore: raise the Dependabot cooldown to five days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,34 @@
 version: 2
+
+# Cooldown: a release has to be five days old before Dependabot opens a version
+# update for it. Dependabot's own default has been three days since 2026-07-14;
+# raising it here also records the choice, so a future change to that default
+# cannot silently shrink the window.
+#
+# Five days is the window we use across our repos, calibrated on registry
+# compromises where a malicious *new release* was published (chalk/debug,
+# shai-hulud, keyv/cacheable): those were all detected within hours to days.
+# With `interval: weekly` the practical delay is "at least five days, at most
+# until the next weekly run".
+#
+# Be honest about what that does not cover here. The dominant Actions-side
+# incident, tj-actions/changed-files (CVE-2025-30066), was a tag *retargeting*:
+# existing version tags were repointed at a malicious commit, so there was no
+# new release for Dependabot to propose and no cooldown window to wait out.
+# Our workflows pin by floating major tag, so that attack reaches CI
+# immediately and cooldown does nothing about it. Only SHA pinning closes it -
+# Dependabot maintains SHA pins fine, and that is worth doing separately.
+#
+# This applies to version updates only. Dependabot *security* updates are
+# exempt from cooldown and keep opening immediately, so advisory fixes are not
+# delayed by this.
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     labels:
       - "dependencies"
     groups:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+- Dependabot waits five days before proposing a new action version (`cooldown.default-days: 5`), raising the built-in three-day default so a compromised release has more time to be spotted. Security updates are exempt and still arrive immediately. No effect on the published actions.
+
 ## [4.0.6] - 2026-06-19
 
 ### Changed


### PR DESCRIPTION
Sets `cooldown: default-days: 5` on the github-actions update block, plus a CHANGELOG entry under `[Unreleased]`.

## What this actually changes

Dependabot has applied a **three-day cooldown by default since 2026-07-14**. So this is 3 → 5 days, not 0 → 5. The explicit setting also pins the choice, so a later change to that default cannot silently shrink the window.

Five days is the window we use across our repos, calibrated on compromises where a malicious **new release** was published (chalk/debug, shai-hulud, keyv/cacheable) — all detected within hours to days. With `interval: weekly` the practical delay is *at least* five days and at most until the next weekly run.

Cooldown covers **version** updates only — Dependabot security updates are exempt and keep opening immediately.

## What this does not buy us

The dominant Actions-side incident, **tj-actions/changed-files (CVE-2025-30066)**, was a tag *retargeting*: existing version tags were repointed at a malicious commit. No new release was published, so there was no version-update PR and no cooldown window to wait out — cooldown would not have helped at all.

Our workflows pin by floating major tag (`actions/checkout@v6`, `softprops/action-gh-release@v3`, `astral-sh/setup-uv@v6`), so that attack class reaches CI immediately. Only **SHA pinning** closes it, and Dependabot maintains SHA pins fine. That is a bigger change than this PR, so it is recorded in the config comment — worth a follow-up decision.

In other words: this PR helps against the npm-style "malicious new release" case and does nothing against the tag-mutation case. Both are stated in the file so the next reader does not over-trust it.