### PR TITLE
feat(deploy): accept auth challenges in the readiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `deploy`: new `health-status-codes` input to control which HTTP codes the `wait-for-ready` check accepts. Takes single codes and ranges (e.g. `200,204` or `200-399,401`)
+
+### Fixed
+- `deploy`: the `wait-for-ready` check no longer fails deployments that sit behind authentication. `401` and `403` now count as ready by default, since an auth challenge proves the app is serving; previously only `200-399` passed and such deployments timed out
+
 ### Internal
 - Dependabot waits five days before proposing a new action version (`cooldown.default-days: 5`), raising the built-in three-day default so a compromised release has more time to be spotted. Security updates are exempt and still arrive immediately. No effect on the published actions.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -20,6 +20,7 @@ Deploys a container image to ZAD Operations Manager.
 | `comment-header` | No | `## 🚀 Preview Deployment` | Custom header for the PR comment |
 | `wait-for-ready` | No | `false` | Wait for deployment to be reachable |
 | `health-endpoint` | No | `/` | Endpoint to check for readiness |
+| `health-status-codes` | No | `200-399,401,403` | Comma-separated HTTP codes/ranges that count as ready (see [Readiness Status Codes](#readiness-status-codes)) |
 | `wait-timeout` | No | `300` | Maximum wait time in seconds |
 | `wait-interval` | No | `10` | Seconds between readiness checks |
 | `qr-code` | No | `false` | Include QR code for mobile access (generated locally via qrencode) |
@@ -331,6 +332,29 @@ Wait for deployment to be healthy using the built-in `wait-for-ready` feature:
     image: ghcr.io/org/app:latest
     wait-for-ready: true
     health-endpoint: /health
+```
+
+### Readiness Status Codes
+
+The readiness check treats `200-399`, `401` and `403` as ready. An app behind authentication answers
+the health check with `401` or `403`, which still proves it is up and serving — only a network error,
+a `404`, or a `5xx` keeps the check pending.
+
+Override with `health-status-codes` when your app needs stricter or different codes. Accepts single
+codes and ranges, comma-separated:
+
+```yaml
+- name: Deploy to ZAD
+  uses: RijksICTGilde/zad-actions/deploy@v4
+  with:
+    api-key: ${{ secrets.ZAD_API_KEY }}
+    project-id: my-project
+    deployment-name: production
+    component: web
+    image: ghcr.io/org/app:latest
+    wait-for-ready: true
+    health-endpoint: /health
+    health-status-codes: '200,204'
 ```
 
 ## Retry Behavior

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -69,6 +69,12 @@ inputs:
     description: 'Endpoint to check for readiness (e.g., /, /health)'
     required: false
     default: '/'
+  health-status-codes:
+    description: >-
+      Comma-separated HTTP codes/ranges that count as ready (e.g. "200-399,401,403").
+      401/403 are included by default because an auth challenge proves the app is serving.
+    required: false
+    default: '200-399,401,403'
   wait-timeout:
     description: 'Maximum time to wait for deployment in seconds'
     required: false
@@ -332,9 +338,39 @@ runs:
         DEPLOYMENT_URLS: ${{ steps.deploy.outputs.urls }}
         COMPONENTS: ${{ inputs.components }}
         HEALTH_ENDPOINT: ${{ inputs.health-endpoint }}
+        HEALTH_STATUS_CODES: ${{ inputs.health-status-codes }}
         WAIT_TIMEOUT: ${{ inputs.wait-timeout }}
         WAIT_INTERVAL: ${{ inputs.wait-interval }}
       run: |
+        # Validate the accepted status codes before using them
+        CODE_SPEC="${HEALTH_STATUS_CODES// /}"
+        if ! echo "$CODE_SPEC" | grep -qE '^[1-5][0-9]{2}(-[1-5][0-9]{2})?(,[1-5][0-9]{2}(-[1-5][0-9]{2})?)*$'; then
+          echo "::error::Invalid health-status-codes: expected codes or ranges like '200-399,401,403'"
+          exit 1
+        fi
+
+        # Does an observed HTTP code match the accepted spec?
+        is_healthy_code() {
+          local code="$1" spec lo hi
+          local -a SPECS
+          IFS=',' read -ra SPECS <<< "$CODE_SPEC"
+          for spec in "${SPECS[@]}"; do
+            case "$spec" in
+              *-*)
+                lo="${spec%%-*}"
+                hi="${spec##*-}"
+                if [ "$code" -ge "$lo" ] && [ "$code" -le "$hi" ]; then return 0; fi
+                ;;
+              *)
+                if [ "$code" -eq "$spec" ]; then return 0; fi
+                ;;
+            esac
+          done
+          return 1
+        }
+
+        echo "Accepting HTTP status codes: $CODE_SPEC"
+
         # Build list of URLs to check (tab-separated: name\turl)
         if [ -n "$COMPONENTS" ] && [ -n "$DEPLOYMENT_URLS" ]; then
           PENDING=$(echo "$DEPLOYMENT_URLS" | jq -r 'to_entries[] | "\(.key)\t\(.value)"')
@@ -348,7 +384,7 @@ runs:
           STILL_PENDING=""
           while IFS=$'\t' read -r name url; do
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${url}${HEALTH_ENDPOINT}" || echo "000")
-            if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 400 ]; then
+            if is_healthy_code "$HTTP_CODE"; then
               echo "$name is ready (HTTP $HTTP_CODE)"
             else
               STILL_PENDING+="${name}\t${url}\n"

--- a/skills/debug-deploy/SKILL.md
+++ b/skills/debug-deploy/SKILL.md
@@ -58,7 +58,8 @@ All three actions retry transient ZAD API errors (000, 429, 500-504) with expone
 
 | Symptom | Diagnosis | Fix |
 |---------|-----------|-----|
-| Timeout waiting for deployment | Container not starting or slow startup | Increase `wait-timeout` (default: 300s). Check container logs in ZAD. Verify `health-endpoint` returns HTTP 2xx/3xx |
+| Timeout waiting for deployment | Container not starting or slow startup | Increase `wait-timeout` (default: 300s). Check container logs in ZAD. Verify `health-endpoint` returns an accepted code (default `200-399`, `401`, `403`) |
+| Timeout while the endpoint answers 4xx | Health endpoint returns a code outside the accepted set (e.g. `404` on the path, or a custom auth code) | Point `health-endpoint` at a path the app actually serves, or widen `health-status-codes` (e.g. `200-399,401,403,404`) |
 | HTTP 502/503 from health endpoint | Container crashing or not listening on correct port | Check container listens on the expected port. Verify environment variables are set correctly in ZAD |
 
 ### GitHub environment deletion errors


### PR DESCRIPTION
## Probleem

De `wait-for-ready` check accepteerde alleen HTTP `200-399`. Deployments achter authenticatie antwoorden op de health-endpoint met `401` of `403`, dus die bleven pollen tot `wait-timeout` en lieten de job falen terwijl de app prima draaide.

## Oplossing

- Nieuwe input `health-status-codes` bepaalt welke codes als "ready" tellen. Accepteert losse codes en ranges, bijv. `200,204` of `200-399,401`.
- Default `200-399,401,403`: een auth-challenge bewijst dat de app serveert.
- Netwerkfouten (`000`), `404` en `5xx` houden de check onveranderd pending.
- De input wordt gevalideerd (`[1-5]xx`, optionele ranges, komma-gescheiden) vóór gebruik; ongeldige waarden falen met een duidelijke `::error::`.

Docs bijgewerkt: inputtabel + sectie "Readiness Status Codes" in `deploy/README.md`, troubleshooting-rij in de `debug-deploy` skill, en CHANGELOG onder `[Unreleased]`.

## Release

Nieuwe input, backwards-compatible → semver minor: **v4.1.0** na merge.

## Test

`pre-commit run --all-files` groen. Matchlogica los getest tegen `000/200/204/301/400/401/403/404/500/502` en tegen overrides (`200`, `200-299, 401`) plus een ongeldige spec.